### PR TITLE
Use the Debian based chip-build container from the wheels project

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,11 +82,11 @@ jobs:
       matrix:
         arch:
           - name: x86-64
-            container: ghcr.io/project-chip/chip-build:42
+            container: ghcr.io/project-chip/chip-build:91
             runner: ubuntu-22.04
             example-prefix: linux-x64-
           - name: aarch64
-            container: docker.io/agners/aarch64-chip-build:42
+            container: docker.io/agners/aarch64-chip-build:91
             runner: linux-arm64
             example-prefix: linux-arm64-
         include:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,11 +82,9 @@ jobs:
       matrix:
         arch:
           - name: x86-64
-            container: ghcr.io/project-chip/chip-build:129
             runner: ubuntu-22.04
             example-prefix: linux-x64-
           - name: aarch64
-            container: docker.io/agners/aarch64-chip-build:129
             runner: linux-arm64
             example-prefix: linux-arm64-
         include:
@@ -121,7 +119,7 @@ jobs:
         working-directory: ./connectedhomeip/
 
     container:
-      image: ${{ matrix.arch.container }}
+      image: ghcr.io/home-assistant-libs/chip-wheels/chip-wheels-builder:release
       volumes:
         - "/tmp/log_output:/tmp/test_logs"
       options: --sysctl "net.ipv6.conf.all.disable_ipv6=0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,11 +82,11 @@ jobs:
       matrix:
         arch:
           - name: x86-64
-            container: ghcr.io/project-chip/chip-build:91
+            container: ghcr.io/project-chip/chip-build:129
             runner: ubuntu-22.04
             example-prefix: linux-x64-
           - name: aarch64
-            container: docker.io/agners/aarch64-chip-build:91
+            container: docker.io/agners/aarch64-chip-build:129
             runner: linux-arm64
             example-prefix: linux-arm64-
         include:


### PR DESCRIPTION
Use the Debian based chip-build container from the wheels project (https://github.com/home-assistant-libs/chip-wheels/), similar to how I've done it with the OTA Provider app: https://github.com/home-assistant-libs/matter-linux-ota-provider/commit/8a8c003f15890d70773ca0edc1e33cc699f6878f.